### PR TITLE
Error with the use of .INCLUDE

### DIFF
--- a/zcl_op_simple_field_catalog.clas.abap
+++ b/zcl_op_simple_field_catalog.clas.abap
@@ -118,11 +118,16 @@ CLASS zcl_op_simple_field_catalog IMPLEMENTATION.
                                      outputlen  = element_description->output_length ) TO r_field_catalog.
           ENDIF.
         WHEN 'S'.
-          DATA(structure_description) = CAST cl_abap_structdescr( component-type ).
-          APPEND VALUE lvc_s_fcat( fieldname  = component-name
-                                   seltext    = component-name
-                                   inttype    = structure_description->type_kind
-                                   datatype   = |STRU| ) TO r_field_catalog.
+          if component-as_include = abap_true.
+            data(lt_aux) = me->get_fieldcat_from_local_type( i_structure_description = cast #( component-type ) ).
+            append lines of lt_aux to r_field_catalog.
+          else.
+            DATA(structure_description) = CAST cl_abap_structdescr( component-type ).
+            APPEND VALUE lvc_s_fcat( fieldname  = component-name
+                                     seltext    = component-name
+                                     inttype    = structure_description->type_kind
+                                     datatype   = |STRU| ) TO r_field_catalog.
+          endif.
         WHEN 'T'.
           DATA(table_description) = CAST cl_abap_tabledescr( component-type ).
           APPEND VALUE #(  fieldname = component-name

--- a/zcl_op_simple_field_catalog.clas.testclasses.abap
+++ b/zcl_op_simple_field_catalog.clas.testclasses.abap
@@ -11,7 +11,8 @@ CLASS ltcl_fieldcatalog_should DEFINITION FINAL FOR TESTING
     METHODS:
       setup,
       get_fields_in_right_order         FOR TESTING RAISING cx_static_check,
-      get_fieldcatalog_of_local_type    FOR TESTING RAISING cx_static_check.
+      get_fieldcatalog_of_local_type    FOR TESTING RAISING cx_static_check,
+      get_fieldcat_of_local_typ_incl    for testing raising cx_static_check.
 ENDCLASS.
 
 
@@ -108,5 +109,160 @@ CLASS ltcl_fieldcatalog_should IMPLEMENTATION.
                                                           msg     = |Field catalog was not created|         ).
 
   ENDMETHOD.
+
+  method get_fieldcat_of_local_typ_incl.
+
+    types begin of gtyp_struct.
+    include type t000.
+    types dummy_field_1 type i.
+    types dummy_field_2 type string.
+    types end of gtyp_struct .
+
+    data(ls_struct)
+        = value gtyp_struct(
+            mandt         = '000'
+            logsys        = 'DUMMY_1'
+            dummy_field_1 = 666
+            dummy_field_2 = 'Hello'
+        ).
+
+    data(lt_field_catalog_act)
+        = lo_cut->get_fieldcat_from_local_type(
+            i_structure_description
+                = cast cl_abap_structdescr( cl_abap_structdescr=>describe_by_data( p_data = ls_struct ) )
+        ).
+
+    data(lt_field_catalog_exp) = value lvc_t_fcat(
+                       (
+                        fieldname = 'MANDT'
+                        outputlen = '000003'
+                        seltext = 'MANDT'
+                        inttype = 'C'
+                        )
+                       (
+                        fieldname = 'MTEXT'
+                        outputlen = '000025'
+                        seltext = 'MTEXT'
+                        inttype = 'C'
+                        )
+                       (
+                        fieldname = 'ORT01'
+                        outputlen = '000025'
+                        seltext = 'ORT01'
+                        inttype = 'C'
+                        )
+                       (
+                        fieldname = 'MWAER'
+                        outputlen = '000005'
+                        seltext = 'MWAER'
+                        inttype = 'C'
+                        )
+                       (
+                        fieldname = 'ADRNR'
+                        outputlen = '000010'
+                        seltext = 'ADRNR'
+                        inttype = 'C'
+                        )
+                       (
+                        fieldname = 'CCCATEGORY'
+                        outputlen = '000001'
+                        seltext = 'CCCATEGORY'
+                        inttype = 'C'
+                        )
+                       (
+                        fieldname = 'CCCORACTIV'
+                        outputlen = '000001'
+                        seltext = 'CCCORACTIV'
+                        inttype = 'C'
+                        )
+                       (
+                        fieldname = 'CCNOCLIIND'
+                        outputlen = '000001'
+                        seltext = 'CCNOCLIIND'
+                        inttype = 'C'
+                        )
+                       (
+                        fieldname = 'CCCOPYLOCK'
+                        outputlen = '000001'
+                        seltext = 'CCCOPYLOCK'
+                        inttype = 'C'
+                        )
+                       (
+                        fieldname = 'CCNOCASCAD'
+                        outputlen = '000001'
+                        seltext = 'CCNOCASCAD'
+                        inttype = 'C'
+                        )
+                       (
+                        fieldname = 'CCSOFTLOCK'
+                        outputlen = '000001'
+                        seltext = 'CCSOFTLOCK'
+                        inttype = 'C'
+                        )
+                       (
+                        fieldname = 'CCORIGCONT'
+                        outputlen = '000001'
+                        seltext = 'CCORIGCONT'
+                        inttype = 'C'
+                        )
+                       (
+                        fieldname = 'CCIMAILDIS'
+                        outputlen = '000001'
+                        seltext = 'CCIMAILDIS'
+                        inttype = 'C'
+                        )
+                       (
+                        fieldname = 'CCTEMPLOCK'
+                        outputlen = '000001'
+                        seltext = 'CCTEMPLOCK'
+                        inttype = 'C'
+                        )
+                       (
+                        fieldname = 'CHANGEUSER'
+                        outputlen = '000012'
+                        seltext = 'CHANGEUSER'
+                        inttype = 'C'
+                        )
+                       (
+                        fieldname = 'CHANGEDATE'
+                        outputlen = '000010'
+                        seltext = 'CHANGEDATE'
+                        inttype = 'D'
+                        )
+                       (
+                        fieldname = 'LOGSYS'
+                        outputlen = '000010'
+                        convexit = '==ALP'
+                        seltext = 'LOGSYS'
+                        inttype = 'C'
+                        )
+                       (
+                        fieldname = 'DUMMY_FIELD_1'
+                        outputlen = '000011'
+                        seltext = 'DUMMY_FIELD_1'
+                        inttype = 'I'
+                        )
+                       (
+                        fieldname = 'DUMMY_FIELD_2'
+                        seltext = 'DUMMY_FIELD_2'
+                        inttype = 'g'
+                        )
+                       ).
+
+
+    cl_abap_unit_assert=>assert_equals(
+      exporting
+        act                  = lt_field_catalog_act
+        exp                  = lt_field_catalog_exp
+*    ignore_hash_sequence = abap_false
+*    tol                  =
+*    msg                  =
+*    level                = if_abap_unit_constant=>severity-medium
+*    quit                 = if_abap_unit_constant=>quit-test
+*  receiving
+*    assertion_failed     =
+    ).
+
+  endmethod.
 
 ENDCLASS.


### PR DESCRIPTION
The field catalog is not built correctly when the definition of the structure/table use '.INCLUDE'. This pull request contain the fix and the Unit Test.